### PR TITLE
fix(fol): handle atomless (tautology) formulas in QFFormula.models

### DIFF
--- a/src/wfomc/fol/syntax.py
+++ b/src/wfomc/fol/syntax.py
@@ -229,11 +229,16 @@ class QFFormula(Formula):
         if not self.satisfiable():
             return
 
+        # A formula with no atoms (e.g. a tautology like ``top``) has exactly
+        # one model: the empty assignment. The backend would otherwise yield a
+        # boolean constant (sympy ``True`` / ``None``) that is not a registered
+        # atom, so it is filtered out below.
         for model in backend.get_models(self.expr):
             yield frozenset(
                 backend.get_atom(
                     symbol) if value else ~backend.get_atom(symbol)
                 for symbol, value in model.items()
+                if symbol in backend.sym2atom
             )
 
     def substitute(self, substitution: dict[Term, Term]) -> QFFormula:

--- a/tests/test_formula_models.py
+++ b/tests/test_formula_models.py
@@ -1,0 +1,23 @@
+"""Regression tests for QFFormula.models() on atomless / tautology formulas."""
+from wfomc.fol.syntax import top, bot, Pred, X
+
+
+def test_top_formula_has_single_empty_model():
+    # A tautology has no atoms, so it has exactly one model: the empty
+    # assignment. Previously models() raised because the SAT backend returned a
+    # boolean constant (True / None) that is not a registered atom.
+    assert list(top.models()) == [frozenset()]
+
+
+def test_unsatisfiable_formula_has_no_models():
+    P = Pred("P", 1)
+    assert list((P(X) & ~P(X)).models()) == []
+
+
+def test_atomic_formula_models_unchanged():
+    P = Pred("P", 1)
+    assert list(P(X).models()) == [frozenset({P(X)})]
+    assert set((P(X) | ~P(X)).models()) == {
+        frozenset({P(X)}),
+        frozenset({~P(X)}),
+    }


### PR DESCRIPTION
## Problem

`QFFormula.models()` crashes on a formula with no atoms (a tautology such as
`top`, or a sentence that reduces to `True`):

```
RuntimeError: ('Symbol %s not found', True)   # or None
```

The SAT backend (`satisfiable(expr, all_models=True)`) returns a model keyed by
a boolean constant (`sympy.true` / `None`) for atomless formulas, and
`get_atom` rejects it. This crashes cell-graph construction, e.g. WFOMC of
`\forall X: True` — reachable from downstream callers (Cofola encodes some
trivially-true problems this way, e.g. `set_0 subset choose(set_0, |set_0|)`).

## Fix

Filter out non-atom symbols in `models()`, so an atomless formula yields its one
model — the empty assignment — instead of raising. Normal formulas are
unaffected (all their symbols are registered atoms).

## Tests

- New `tests/test_formula_models.py`: `top.models() == [frozenset()]`,
  unsatisfiable formula → `[]`, atomic/`P|~P` formulas unchanged.
- Verified end-to-end: the Cofola example now returns `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)