### PR TITLE
fix(propositional): return 1 for empty CNF instead of crashing ganak

### DIFF
--- a/src/wfomc/algo/ganak.py
+++ b/src/wfomc/algo/ganak.py
@@ -202,6 +202,13 @@ def ganak_count(n_vars: int,
     Raises:
         GanakError: When ganak is missing, fails, or returns bad output.
     """
+    if n_vars == 0:
+        # Empty CNF (no propositional variables): exactly one model with
+        # weight 1. ganak asserts on empty input, so return the identity
+        # directly without invoking the binary (it also avoids needing ganak
+        # installed for trivially-true groundings).
+        return fmpq(1)
+
     binary = find_ganak(ganak_path)
     clauses = [list(clause) for clause in clauses]
 

--- a/tests/test_ganak_count.py
+++ b/tests/test_ganak_count.py
@@ -1,0 +1,12 @@
+"""Regression test for ganak_count on a degenerate (empty) CNF.
+
+Does not require the ganak binary: the empty-CNF case short-circuits before the
+binary is located.
+"""
+from wfomc.algo.ganak import ganak_count
+
+
+def test_ganak_count_empty_cnf_returns_one():
+    # No propositional variables -> exactly one (empty) model with weight 1.
+    # ganak asserts on empty input, so ganak_count must short-circuit.
+    assert ganak_count(0, [], {}) == 1


### PR DESCRIPTION
## Problem

`Algo.PROPOSITIONAL` crashes on a trivially-true grounding (no propositional
variables). The empty CNF makes ganak abort:

```
Assertion failed: (!incidence.empty() && "Incidence is filled at fill_solver time")
```

Reachable from downstream callers — e.g. Cofola's `set_0 subset choose(set_0, |set_0|)`
reduces to `\forall X: True`, which grounds to an empty CNF.

## Fix

`ganak_count` short-circuits when `n_vars == 0`, returning the single empty
model's weight (1) instead of invoking ganak. As a bonus, such trivially-true
inputs no longer require a ganak binary at all.

## Tests

- New `tests/test_ganak_count.py`: `ganak_count(0, [], {}) == 1` (runs without
  ganak installed).
- Propositional suite still green.

Companion to #16 (which fixed the lifted algorithms for the same class of
atomless-formula inputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)