### PR TITLE
feat: accelerate Fast symmetric cliques

### DIFF
--- a/docs/plans/2026-07-21-fast-symmetric-convolution-design.md
+++ b/docs/plans/2026-07-21-fast-symmetric-convolution-design.md
@@ -1,0 +1,46 @@
+# Fast Symmetric-Clique Convolution Design
+
+## Goal
+
+Replace Fast's cell-by-cell symmetric-clique recurrence with the dense twisted
+binomial convolution and repeated-squaring strategy already validated by the
+boundary-profile solver, without coupling Fast to boundary-profile modules.
+
+## Architecture
+
+Add `wfomc.algo.symmetric_clique`, an algorithm-neutral internal module.  Its
+convolver computes
+
+```text
+(A star_r B)[n] = sum_i choose(n, i) A[i] B[n-i] r^(i(n-i))
+```
+
+over the active `ArithmeticContext`.  The operation is associative and
+commutative, so identical local rows can be raised to a cell multiplicity with
+binary exponentiation.  The API accepts already-materialized local rows; Fast
+therefore retains its existing convention about whether cell weights live
+inside or outside the J-term.
+
+Fast materialized operations lazily build and cache one complete J-message per
+clique and domain.  Ordinary Fast cliques are homogeneous and always use the
+power path.  FastV2 and evidence-aware cliques may contain heterogeneous local
+rows: equal rows are grouped and powered, then the group messages are combined.
+The existing scalar recurrence remains temporarily available as an oracle and
+fallback while the new path is validated.
+
+## Rebase boundary
+
+This branch starts from `devel` and does not touch
+`wfomc.algo.boundary_profile`.  When `bp-dp` is rebased, its private
+`_Combinatorics`, `_PowerRow`, `_ExponentCache`, and
+`_combine_one_dimensional` can be replaced by the shared convolver without a
+path-level rebase conflict.
+
+## Correctness and performance
+
+Unit tests compare every coefficient with a direct recurrence across exact and
+symbolic arithmetic, verify associativity, and count combines to prove the
+logarithmic homogeneous path.  Fast/FastV2 integration tests cover ordinary and
+unary-evidence solving.  Benchmarks must compare only paired successful cases
+and include clique size because the optimization targets large repeated
+cliques.

--- a/docs/plans/2026-07-21-fast-symmetric-convolution.md
+++ b/docs/plans/2026-07-21-fast-symmetric-convolution.md
@@ -1,0 +1,45 @@
+# Fast Symmetric-Clique Convolution Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Share BP-DP's twisted binomial convolution method with Fast and use repeated squaring for homogeneous symmetric cliques.
+
+**Architecture:** Introduce an algorithm-neutral convolver over `ArithmeticContext`, then make Fast operations cache full clique messages instead of evaluating one recursive D-term at a time. Keep boundary-profile files untouched so the later `bp-dp` rebase is conflict-light.
+
+**Tech Stack:** Python 3.11, python-flint, pytest, existing typed WFOMC engine.
+
+---
+
+### Task 1: Shared convolution primitive
+
+**Files:**
+- Create: `src/wfomc/algo/symmetric_clique.py`
+- Create: `tests/unit/test_symmetric_clique_convolution.py`
+
+1. Add failing coefficient, associativity, symbolic-arithmetic, and combine-count tests.
+2. Implement cached binomial coefficients and interaction powers.
+3. Implement dense convolution, binary power, and grouped product.
+4. Run the focused tests and commit.
+
+### Task 2: Fast integration
+
+**Files:**
+- Modify: `src/wfomc/algo/fast/weights.py`
+- Modify: `src/wfomc/algo/fast/operations.py`
+- Create: `tests/unit/test_fast_symmetric_convolution.py`
+
+1. Add tests comparing cached clique messages with the legacy D-term recurrence.
+2. Add per-domain message caches to both operation implementations.
+3. Build local rows with Fast's existing weight-placement semantics.
+4. Route ordinary and evidence J-terms through grouped convolution products.
+5. Run Fast unit/integration tests and commit.
+
+### Task 3: Verify and merge
+
+**Files:**
+- No additional production files.
+
+1. Run compile checks, focused tests, full pytest, and Fast benchmark smoke.
+2. Confirm `bp-dp`-owned paths are untouched.
+3. Switch to `devel` and merge with `--ff-only`.
+4. Confirm `devel` is clean and record the resulting commit.

--- a/docs/plans/2026-07-21-fast-symmetric-convolution.md
+++ b/docs/plans/2026-07-21-fast-symmetric-convolution.md
@@ -1,6 +1,5 @@
 # Fast Symmetric-Clique Convolution Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Share BP-DP's twisted binomial convolution method with Fast and use repeated squaring for homogeneous symmetric cliques.
 

--- a/src/wfomc/algo/fast/operations.py
+++ b/src/wfomc/algo/fast/operations.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import math
 
+from wfomc.algo.symmetric_clique import TwistedBinomialConvolver
 from wfomc.arithmetic import ArithmeticValue
 from .weights import (
     optimized_J_term,
     optimized_d_term,
     optimized_term,
+    symmetric_clique_row,
 )
 
 
@@ -42,6 +44,9 @@ class MaterializedOptimizedOperations:
         self.term_cache: dict = {}
         self.j_term_cache: dict = {}
         self.d_term_cache: dict = {}
+        self.symmetric_message_cache: dict[
+            int, tuple[ArithmeticValue, ...]
+        ] = {}
 
     def get_cell_weight(self, cell) -> ArithmeticValue:
         return self._cell_weight[cell]
@@ -81,6 +86,7 @@ class MaterializedOptimizedEvidenceOperations:
         nonind_map,
         i1_evidence_profile_partition,
         clique_evidence_profile_partitions,
+        domain_size,
         cell_weight,
         two_table,
         arithmetic,
@@ -91,6 +97,7 @@ class MaterializedOptimizedEvidenceOperations:
         self.nonind_map = nonind_map
         self.i1_evidence_profile_partition = i1_evidence_profile_partition
         self.clique_evidence_profile_partitions = clique_evidence_profile_partitions
+        self.domain_size = domain_size
         self._cell_weight = cell_weight
         self._two_table = two_table
         self.arithmetic = arithmetic
@@ -99,6 +106,9 @@ class MaterializedOptimizedEvidenceOperations:
             tuple[int, int, int], ArithmeticValue
         ] = {}
         self._d_term_cache: dict[tuple[int, int, int, int], ArithmeticValue] = {}
+        self.partitioned_message_cache: dict[
+            tuple[int, int], tuple[ArithmeticValue, ...]
+        ] = {}
 
     def get_cell_weight(self, cell) -> ArithmeticValue:
         return self._cell_weight[cell]
@@ -184,6 +194,13 @@ class MaterializedOptimizedEvidenceOperations:
         cached = self._partitioned_j_term_cache.get(key)
         if cached is not None:
             return cached
+        if self.domain_size is not None:
+            result = self._get_partitioned_J_message(
+                clique_idx,
+                partition_idx,
+            )[count]
+            self._partitioned_j_term_cache[key] = result
+            return result
         cell_indices = self.clique_evidence_profile_partitions[clique_idx][
             partition_idx
         ]
@@ -201,6 +218,47 @@ class MaterializedOptimizedEvidenceOperations:
             result = self.get_d_term(clique_idx, count, partition_idx)
         self._partitioned_j_term_cache[key] = result
         return result
+
+    def _get_partitioned_J_message(
+        self,
+        clique_idx: int,
+        partition_idx: int,
+    ) -> tuple[ArithmeticValue, ...]:
+        key = (clique_idx, partition_idx)
+        cached = self.partitioned_message_cache.get(key)
+        if cached is not None:
+            return cached
+        if self.domain_size is None:
+            raise RuntimeError("optimized operations are not bound to a domain")
+
+        clique = self.cliques[clique_idx]
+        cell_indices = self.clique_evidence_profile_partitions[clique_idx][
+            partition_idx
+        ]
+        if not cell_indices:
+            raise ValueError("evidence clique partitions must contain a cell")
+        cells = [clique[cell_index] for cell_index in cell_indices]
+        rows = [
+            symmetric_clique_row(
+                self.domain_size,
+                self.get_cell_weight(cell),
+                self.get_two_table_weight((cell, cell)),
+                self.arithmetic,
+            )
+            for cell in cells
+        ]
+        interaction = (
+            self.get_two_table_weight((cells[0], cells[1]))
+            if len(cells) > 1
+            else self.arithmetic.one()
+        )
+        message = TwistedBinomialConvolver(
+            self.domain_size,
+            interaction,
+            self.arithmetic,
+        ).product(rows)
+        self.partitioned_message_cache[key] = message
+        return message
 
     def get_d_term(
         self,
@@ -295,6 +353,7 @@ def materialize_optimized_operations(graph) -> OptimizedOperations:
             clique_evidence_profile_partitions=dict(
                 graph.clique_evidence_profile_partitions
             ),
+            domain_size=None,
             cell_weight=cell_weight,
             two_table=two_table,
             arithmetic=graph.arithmetic,
@@ -341,6 +400,7 @@ def instantiate_optimized_operations(
             clique_evidence_profile_partitions=dict(
                 operations.clique_evidence_profile_partitions
             ),
+            domain_size=domain_size,
             cell_weight=cell_weight,
             two_table=two_table,
             arithmetic=arithmetic,

--- a/src/wfomc/algo/fast/weights.py
+++ b/src/wfomc/algo/fast/weights.py
@@ -14,7 +14,30 @@ from __future__ import annotations
 
 import math
 
+from wfomc.algo.symmetric_clique import TwistedBinomialConvolver
 from wfomc.arithmetic import ArithmeticValue
+
+
+def symmetric_clique_row(
+    domain_size: int,
+    weight: ArithmeticValue,
+    self_interaction: ArithmeticValue,
+    arithmetic,
+) -> tuple[ArithmeticValue, ...]:
+    """Return ``weight^n * self_interaction^choose(n, 2)`` for all ``n``."""
+
+    row = [arithmetic.one()]
+    value = arithmetic.one()
+    interaction_power = arithmetic.one()
+    for _count in range(1, domain_size + 1):
+        value = arithmetic.multiply(value, weight)
+        value = arithmetic.multiply(value, interaction_power)
+        row.append(value)
+        interaction_power = arithmetic.multiply(
+            interaction_power,
+            self_interaction,
+        )
+    return tuple(row)
 
 
 def optimized_term(
@@ -88,7 +111,12 @@ def optimized_J_term(ops, clique_idx: int, nhat: int) -> ArithmeticValue:
     if key in ops.j_term_cache:
         return ops.j_term_cache[key]
 
-    if len(ops.cliques[clique_idx]) == 1:
+    if (
+        getattr(ops, "domain_size", None) is not None
+        and hasattr(ops, "symmetric_message_cache")
+    ):
+        thesum = optimized_J_message(ops, clique_idx)[nhat]
+    elif len(ops.cliques[clique_idx]) == 1:
         thesum = ops.arithmetic.power(
             ops.get_two_table_weight(
                 (ops.cliques[clique_idx][0], ops.cliques[clique_idx][0])
@@ -107,6 +135,48 @@ def optimized_J_term(ops, clique_idx: int, nhat: int) -> ArithmeticValue:
         thesum = optimized_d_term(ops, clique_idx, nhat)
     ops.j_term_cache[key] = thesum
     return thesum
+
+
+def optimized_J_message(ops, clique_idx: int) -> tuple[ArithmeticValue, ...]:
+    """Build the full cardinality message for one symmetric clique once."""
+
+    cached = ops.symmetric_message_cache.get(clique_idx)
+    if cached is not None:
+        return cached
+    if ops.domain_size is None:
+        raise RuntimeError("optimized operations are not bound to a domain")
+
+    clique = ops.cliques[clique_idx]
+    if not clique:
+        raise ValueError("symmetric cliques must contain at least one cell")
+    rows = []
+    for cell in clique:
+        weight = (
+            ops.get_cell_weight(cell)
+            if ops.modified_cell_symmetry
+            else ops.arithmetic.one()
+        )
+        rows.append(
+            symmetric_clique_row(
+                ops.domain_size,
+                weight,
+                ops.get_two_table_weight((cell, cell)),
+                ops.arithmetic,
+            )
+        )
+
+    interaction = (
+        ops.get_two_table_weight((clique[0], clique[1]))
+        if len(clique) > 1
+        else ops.arithmetic.one()
+    )
+    message = TwistedBinomialConvolver(
+        ops.domain_size,
+        interaction,
+        ops.arithmetic,
+    ).product(rows)
+    ops.symmetric_message_cache[clique_idx] = message
+    return message
 
 
 def optimized_d_term(ops, clique_idx: int, n: int, cur: int = 0) -> ArithmeticValue:
@@ -181,4 +251,10 @@ def optimized_d_term(ops, clique_idx: int, n: int, cur: int = 0) -> ArithmeticVa
     return ret
 
 
-__all__ = ["optimized_term", "optimized_J_term", "optimized_d_term"]
+__all__ = [
+    "optimized_term",
+    "optimized_J_term",
+    "optimized_J_message",
+    "optimized_d_term",
+    "symmetric_clique_row",
+]

--- a/src/wfomc/algo/symmetric_clique.py
+++ b/src/wfomc/algo/symmetric_clique.py
@@ -1,0 +1,200 @@
+"""Shared dense convolution for symmetric cell-graph cliques."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from wfomc.arithmetic import ArithmeticValue
+
+
+class _PowerRow:
+    """Incrementally materialized ``1, base, base^2, ...`` values."""
+
+    def __init__(self, base: ArithmeticValue, arithmetic):
+        self.base = base
+        self.arithmetic = arithmetic
+        self.values = [arithmetic.one()]
+
+    def get(self, exponent: int) -> ArithmeticValue:
+        while len(self.values) <= exponent:
+            self.values.append(
+                self.arithmetic.multiply(self.values[-1], self.base)
+            )
+        return self.values[exponent]
+
+
+class _ExponentCache:
+    """Bounded cache for interaction exponents ``left * right``."""
+
+    _SYMBOLIC_CACHE_LIMIT = 8192
+
+    def __init__(self, base: ArithmeticValue, max_exponent: int, arithmetic):
+        self.base = base
+        self.arithmetic = arithmetic
+        self.sequential = (
+            not arithmetic.symbolic_variables or max_exponent <= 4096
+        )
+        self.row = _PowerRow(base, arithmetic) if self.sequential else None
+        self.values: dict[int, ArithmeticValue] = {0: arithmetic.one()}
+
+    def get(self, exponent: int) -> ArithmeticValue:
+        if self.row is not None:
+            return self.row.get(exponent)
+        cached = self.values.get(exponent)
+        if cached is not None:
+            return cached
+        value = self.arithmetic.power(self.base, exponent)
+        if len(self.values) < self._SYMBOLIC_CACHE_LIMIT:
+            self.values[exponent] = value
+        return value
+
+
+class _BinomialValues:
+    """Pascal rows plus lazily coerced backend values."""
+
+    def __init__(self, maximum: int, arithmetic):
+        rows: list[tuple[int, ...]] = []
+        current = [1]
+        for _ in range(maximum + 1):
+            rows.append(tuple(current))
+            current = [1] + [
+                current[index] + current[index + 1]
+                for index in range(len(current) - 1)
+            ] + [1]
+        self.rows = tuple(rows)
+        self.arithmetic = arithmetic
+        self.values: dict[tuple[int, int], ArithmeticValue] = {}
+
+    def value(self, total: int, selected: int) -> ArithmeticValue:
+        key = (total, selected)
+        cached = self.values.get(key)
+        if cached is None:
+            cached = self.arithmetic.from_int(self.rows[total][selected])
+            self.values[key] = cached
+        return cached
+
+
+class TwistedBinomialConvolver:
+    """Combine symmetric-clique cardinality rows up to one domain size.
+
+    For interaction weight ``r``, the product is
+
+    ``C[n] = sum_i choose(n, i) A[i] B[n-i] r^(i(n-i))``.
+
+    This product is associative and commutative.  Repeated equal rows can
+    therefore be combined with binary exponentiation.
+    """
+
+    def __init__(
+        self,
+        domain_size: int,
+        interaction: ArithmeticValue,
+        arithmetic,
+    ):
+        if domain_size < 0:
+            raise ValueError("domain_size must be non-negative")
+        self.domain_size = domain_size
+        self.interaction = interaction
+        self.arithmetic = arithmetic
+        self.binomials = _BinomialValues(domain_size, arithmetic)
+        max_cross = (domain_size // 2) * (domain_size - domain_size // 2)
+        self.interaction_powers = _ExponentCache(
+            interaction,
+            max_cross,
+            arithmetic,
+        )
+
+    def _row(
+        self,
+        values: Sequence[ArithmeticValue],
+    ) -> tuple[ArithmeticValue, ...]:
+        if len(values) != self.domain_size + 1:
+            raise ValueError(
+                "symmetric-clique rows must contain domain_size + 1 values"
+            )
+        return tuple(values)
+
+    def identity(self) -> tuple[ArithmeticValue, ...]:
+        return (self.arithmetic.one(),) + (
+            self.arithmetic.zero(),
+        ) * self.domain_size
+
+    def combine(
+        self,
+        left: Sequence[ArithmeticValue],
+        right: Sequence[ArithmeticValue],
+    ) -> tuple[ArithmeticValue, ...]:
+        """Return the truncated twisted binomial convolution of two rows."""
+
+        left_row = self._row(left)
+        right_row = self._row(right)
+        output = [self.arithmetic.zero() for _ in range(self.domain_size + 1)]
+        for total in range(self.domain_size + 1):
+            accumulator = self.arithmetic.zero()
+            for left_count in range(total + 1):
+                left_value = left_row[left_count]
+                right_value = right_row[total - left_count]
+                if self.arithmetic.is_zero(left_value) or self.arithmetic.is_zero(
+                    right_value
+                ):
+                    continue
+                factor = self.binomials.value(total, left_count)
+                cross_exponent = left_count * (total - left_count)
+                if cross_exponent:
+                    factor = self.arithmetic.multiply(
+                        factor,
+                        self.interaction_powers.get(cross_exponent),
+                    )
+                factor = self.arithmetic.multiply(factor, left_value)
+                accumulator = self.arithmetic.add_product(
+                    accumulator,
+                    factor,
+                    right_value,
+                )
+            output[total] = accumulator
+        return tuple(output)
+
+    def power(
+        self,
+        base: Sequence[ArithmeticValue],
+        multiplicity: int,
+    ) -> tuple[ArithmeticValue, ...]:
+        """Raise one row under convolution using binary exponentiation."""
+
+        if multiplicity < 0:
+            raise ValueError("multiplicity must be non-negative")
+        current = self._row(base)
+        result: tuple[ArithmeticValue, ...] | None = None
+        remaining = multiplicity
+        while remaining:
+            if remaining & 1:
+                result = current if result is None else self.combine(result, current)
+            remaining >>= 1
+            if remaining:
+                current = self.combine(current, current)
+        return self.identity() if result is None else result
+
+    def product(
+        self,
+        rows: Sequence[Sequence[ArithmeticValue]],
+    ) -> tuple[ArithmeticValue, ...]:
+        """Group equal rows, power each group, and combine the groups."""
+
+        groups: list[tuple[tuple[ArithmeticValue, ...], int]] = []
+        for values in rows:
+            row = self._row(values)
+            for index, (existing, count) in enumerate(groups):
+                if existing == row:
+                    groups[index] = (existing, count + 1)
+                    break
+            else:
+                groups.append((row, 1))
+
+        result: tuple[ArithmeticValue, ...] | None = None
+        for row, multiplicity in groups:
+            powered = self.power(row, multiplicity)
+            result = powered if result is None else self.combine(result, powered)
+        return self.identity() if result is None else result
+
+
+__all__ = ["TwistedBinomialConvolver"]

--- a/tests/unit/test_fast_symmetric_convolution.py
+++ b/tests/unit/test_fast_symmetric_convolution.py
@@ -156,6 +156,41 @@ def test_fastv2_groups_equal_local_rows_in_one_convolution_message() -> None:
     assert operations.d_term_cache == {}
 
 
+def test_fast_single_cell_clique_uses_cached_convolution_message() -> None:
+    domain_size = 6
+    interaction = 29
+
+    for modified_cell_symmetry in (False, True):
+        weights = (7,)
+        self_relations = (11,)
+        operations = _ordinary_operations(
+            domain_size=domain_size,
+            weights=weights,
+            self_relations=self_relations,
+            interaction=interaction,
+            modified_cell_symmetry=modified_cell_symmetry,
+        )
+
+        actual = tuple(
+            operations.get_J_term(0, count) for count in range(domain_size + 1)
+        )
+        expected = tuple(
+            _direct_clique_weight(
+                count,
+                weights=weights,
+                self_relations=self_relations,
+                interaction=interaction,
+                include_weights=modified_cell_symmetry,
+                arithmetic=operations.arithmetic,
+            )
+            for count in range(domain_size + 1)
+        )
+
+        assert actual == expected
+        assert list(operations.symmetric_message_cache) == [0]
+        assert operations.d_term_cache == {}
+
+
 def test_evidence_partition_uses_convolution_message() -> None:
     domain_size = 5
     weights = (2, 3, 5, 7)

--- a/tests/unit/test_fast_symmetric_convolution.py
+++ b/tests/unit/test_fast_symmetric_convolution.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import math
+
+from wfomc.algo.fast.operations import (
+    MaterializedOptimizedEvidenceOperations,
+    MaterializedOptimizedOperations,
+    instantiate_optimized_operations,
+)
+from wfomc.arithmetic import ArithmeticBackend, ArithmeticContext
+
+
+def _compositions(total: int, parts: int):
+    if parts == 1:
+        yield (total,)
+        return
+    for first in range(total + 1):
+        for rest in _compositions(total - first, parts - 1):
+            yield (first,) + rest
+
+
+def _direct_clique_weight(
+    count,
+    *,
+    weights,
+    self_relations,
+    interaction,
+    include_weights,
+    arithmetic,
+):
+    result = arithmetic.zero()
+    for allocation in _compositions(count, len(weights)):
+        coefficient = math.factorial(count)
+        for cell_count in allocation:
+            coefficient //= math.factorial(cell_count)
+        term = arithmetic.from_int(coefficient)
+        cross_pairs = 0
+        for cell_index, cell_count in enumerate(allocation):
+            if include_weights:
+                term = arithmetic.multiply(
+                    term,
+                    arithmetic.power(weights[cell_index], cell_count),
+                )
+            term = arithmetic.multiply(
+                term,
+                arithmetic.power(
+                    self_relations[cell_index],
+                    math.comb(cell_count, 2),
+                ),
+            )
+            cross_pairs += cell_count * sum(allocation[cell_index + 1 :])
+        term = arithmetic.multiply(
+            term,
+            arithmetic.power(interaction, cross_pairs),
+        )
+        result = arithmetic.add(result, term)
+    return result
+
+
+def _ordinary_operations(
+    *,
+    domain_size,
+    weights,
+    self_relations,
+    interaction,
+    modified_cell_symmetry,
+):
+    arithmetic = ArithmeticContext(ArithmeticBackend.FMPQ)
+    cells = tuple(f"cell-{index}" for index in range(len(weights)))
+    two_table = {
+        (left, right): (
+            self_relations[left_index]
+            if left_index == right_index
+            else interaction
+        )
+        for left_index, left in enumerate(cells)
+        for right_index, right in enumerate(cells)
+    }
+    return MaterializedOptimizedOperations(
+        cliques=[list(cells)],
+        nonind=[0],
+        nonind_map={0: 0},
+        i1_ind=[],
+        i2_ind=[],
+        domain_size=domain_size,
+        modified_cell_symmetry=modified_cell_symmetry,
+        arithmetic=arithmetic,
+        cell_weight=dict(zip(cells, weights)),
+        two_table=two_table,
+    )
+
+
+def test_fast_homogeneous_clique_uses_one_cached_convolution_message() -> None:
+    domain_size = 6
+    weights = (7,) * 8
+    self_relations = (2,) * 8
+    interaction = 3
+    operations = _ordinary_operations(
+        domain_size=domain_size,
+        weights=weights,
+        self_relations=self_relations,
+        interaction=interaction,
+        modified_cell_symmetry=False,
+    )
+
+    actual = tuple(
+        operations.get_J_term(0, count) for count in range(domain_size + 1)
+    )
+    expected = tuple(
+        _direct_clique_weight(
+            count,
+            weights=weights,
+            self_relations=self_relations,
+            interaction=interaction,
+            include_weights=False,
+            arithmetic=operations.arithmetic,
+        )
+        for count in range(domain_size + 1)
+    )
+
+    assert actual == expected
+    assert list(operations.symmetric_message_cache) == [0]
+    assert operations.d_term_cache == {}
+
+
+def test_fastv2_groups_equal_local_rows_in_one_convolution_message() -> None:
+    domain_size = 5
+    weights = (2, 2, 5, 5, 11)
+    self_relations = (3, 3, 7, 7, 13)
+    interaction = 17
+    operations = _ordinary_operations(
+        domain_size=domain_size,
+        weights=weights,
+        self_relations=self_relations,
+        interaction=interaction,
+        modified_cell_symmetry=True,
+    )
+
+    actual = tuple(
+        operations.get_J_term(0, count) for count in range(domain_size + 1)
+    )
+    expected = tuple(
+        _direct_clique_weight(
+            count,
+            weights=weights,
+            self_relations=self_relations,
+            interaction=interaction,
+            include_weights=True,
+            arithmetic=operations.arithmetic,
+        )
+        for count in range(domain_size + 1)
+    )
+
+    assert actual == expected
+    assert list(operations.symmetric_message_cache) == [0]
+    assert operations.d_term_cache == {}
+
+
+def test_evidence_partition_uses_convolution_message() -> None:
+    domain_size = 5
+    weights = (2, 3, 5, 7)
+    self_relations = (11, 13, 17, 19)
+    interaction = 23
+    arithmetic = ArithmeticContext(ArithmeticBackend.FMPQ)
+    cells = tuple(f"cell-{index}" for index in range(len(weights)))
+    operations = MaterializedOptimizedEvidenceOperations(
+        cells=list(cells),
+        cliques=[list(cells)],
+        nonind=[0],
+        nonind_map={0: 0},
+        i1_evidence_profile_partition=[],
+        clique_evidence_profile_partitions={0: [list(range(len(cells)))]},
+        domain_size=domain_size,
+        arithmetic=arithmetic,
+        cell_weight=dict(zip(cells, weights)),
+        two_table={
+            (left, right): (
+                self_relations[left_index]
+                if left_index == right_index
+                else interaction
+            )
+            for left_index, left in enumerate(cells)
+            for right_index, right in enumerate(cells)
+        },
+    )
+
+    actual = tuple(
+        operations.get_partitioned_J_term(0, 0, count)
+        for count in range(domain_size + 1)
+    )
+    expected = tuple(
+        _direct_clique_weight(
+            count,
+            weights=weights,
+            self_relations=self_relations,
+            interaction=interaction,
+            include_weights=True,
+            arithmetic=arithmetic,
+        )
+        for count in range(domain_size + 1)
+    )
+
+    assert actual == expected
+    assert list(operations.partitioned_message_cache) == [(0, 0)]
+    assert operations._d_term_cache == {}
+
+
+def test_instantiation_keeps_symmetric_messages_domain_local() -> None:
+    template = _ordinary_operations(
+        domain_size=None,
+        weights=(2, 2, 2),
+        self_relations=(3, 3, 3),
+        interaction=5,
+        modified_cell_symmetry=False,
+    )
+    arithmetic = ArithmeticContext(ArithmeticBackend.FMPQ)
+
+    small = instantiate_optimized_operations(
+        template,
+        arithmetic=arithmetic,
+        domain_size=3,
+    )
+    large = instantiate_optimized_operations(
+        template,
+        arithmetic=arithmetic,
+        domain_size=6,
+    )
+    small.get_J_term(0, 3)
+    large.get_J_term(0, 6)
+
+    assert len(small.symmetric_message_cache[0]) == 4
+    assert len(large.symmetric_message_cache[0]) == 7
+    assert small.symmetric_message_cache is not large.symmetric_message_cache

--- a/tests/unit/test_symmetric_clique_convolution.py
+++ b/tests/unit/test_symmetric_clique_convolution.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from math import comb
+
+from wfomc.algo.symmetric_clique import TwistedBinomialConvolver
+from wfomc.arithmetic import ArithmeticBackend, ArithmeticContext
+
+
+def _direct(left, right, interaction, arithmetic):
+    result = []
+    for total in range(len(left)):
+        value = arithmetic.zero()
+        for selected in range(total + 1):
+            factor = arithmetic.from_int(comb(total, selected))
+            factor = arithmetic.multiply(factor, left[selected])
+            factor = arithmetic.multiply(factor, right[total - selected])
+            factor = arithmetic.multiply(
+                factor,
+                arithmetic.power(interaction, selected * (total - selected)),
+            )
+            value = arithmetic.add(value, factor)
+        result.append(value)
+    return tuple(result)
+
+
+def test_twisted_convolution_matches_direct_coefficients() -> None:
+    arithmetic = ArithmeticContext(ArithmeticBackend.FMPQ)
+    left = tuple(arithmetic.from_int(value) for value in (1, 2, 3, 4, 5))
+    right = tuple(arithmetic.from_int(value) for value in (1, 3, 5, 7, 9))
+    interaction = arithmetic.from_int(2)
+    convolver = TwistedBinomialConvolver(4, interaction, arithmetic)
+
+    assert convolver.combine(left, right) == _direct(
+        left, right, interaction, arithmetic
+    )
+
+
+def test_twisted_convolution_is_associative() -> None:
+    arithmetic = ArithmeticContext(ArithmeticBackend.FMPQ)
+    rows = [
+        tuple(arithmetic.from_int(value) for value in values)
+        for values in (
+            (1, 2, 1, 3, 2),
+            (1, 1, 4, 1, 5),
+            (1, 3, 2, 2, 1),
+        )
+    ]
+    convolver = TwistedBinomialConvolver(4, arithmetic.from_int(3), arithmetic)
+
+    assert convolver.combine(convolver.combine(rows[0], rows[1]), rows[2]) == (
+        convolver.combine(rows[0], convolver.combine(rows[1], rows[2]))
+    )
+
+
+class _CountingConvolver(TwistedBinomialConvolver):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.combine_calls = 0
+
+    def combine(self, left, right):
+        self.combine_calls += 1
+        return super().combine(left, right)
+
+
+def test_power_uses_binary_exponentiation() -> None:
+    arithmetic = ArithmeticContext(ArithmeticBackend.FMPQ)
+    base = tuple(arithmetic.from_int(value) for value in (1, 2, 3, 4, 5, 6))
+    interaction = arithmetic.from_int(2)
+    expected_convolver = TwistedBinomialConvolver(5, interaction, arithmetic)
+    expected = base
+    for _ in range(7):
+        expected = expected_convolver.combine(expected, base)
+
+    convolver = _CountingConvolver(5, interaction, arithmetic)
+
+    assert convolver.power(base, 8) == expected
+    assert convolver.combine_calls == 3
+
+
+def test_product_groups_equal_rows_before_powering() -> None:
+    arithmetic = ArithmeticContext(ArithmeticBackend.FMPQ)
+    first = tuple(arithmetic.from_int(value) for value in (1, 2, 3, 4, 5))
+    second = tuple(arithmetic.from_int(value) for value in (1, 1, 2, 3, 5))
+    rows = [first] * 8 + [second] * 2
+    interaction = arithmetic.from_int(2)
+    expected_convolver = TwistedBinomialConvolver(4, interaction, arithmetic)
+    expected = rows[0]
+    for row in rows[1:]:
+        expected = expected_convolver.combine(expected, row)
+
+    convolver = _CountingConvolver(4, interaction, arithmetic)
+
+    assert convolver.product(rows) == expected
+    assert convolver.combine_calls == 5
+
+
+def test_symbolic_convolution_obeys_arithmetic_context() -> None:
+    arithmetic = ArithmeticContext(
+        ArithmeticBackend.FMPQ_POLY,
+        symbolic_variables=("x",),
+        degree_limits=(("x", 6),),
+    )
+    symbol = arithmetic.symbol("x")
+    base = tuple(
+        arithmetic.power(symbol, degree) for degree in range(5)
+    )
+    convolver = TwistedBinomialConvolver(4, symbol, arithmetic)
+
+    assert convolver.power(base, 3) == convolver.combine(
+        convolver.combine(base, base), base
+    )


### PR DESCRIPTION
## Summary

- add a shared dense twisted-binomial convolver for symmetric cell-graph cliques
- switch Fast, FastV2, and evidence-partition clique weights from recursive allocation DP to cached full-cardinality messages
- group identical local rows and use exponentiation by squaring
- keep domain-free input templates reusable while allocating message caches only in domain-bound operations
- preserve the legacy recursion as a compatibility fallback and leave boundary_profile unchanged for the later bp-dp rebase

## Correctness

- full suite: 575 passed, 5 skipped
- post-merge focused suite: 54 passed
- old and new benchmark result hashes match

## Performance

Median old-devel to new timings:

- Fast, 4-coloured/n100: 16.97 ms to 12.43 ms, 1.36x
- Fast, 5-coloured/n75: 13.77 ms to 10.91 ms, 1.26x
- FastV2, 4-coloured/n100: 15.28 ms to 11.43 ms, 1.34x
- FastV2, 5-coloured/n75: 13.58 ms to 8.37 ms, 1.62x

The isolated symmetric-clique kernel improves by about 1.44x, 2.78x, and 5.12x for clique sizes 5, 8, and 16 respectively.
