### PR TITLE
fix: encode cardinality linear forms with one marker

### DIFF
--- a/src/wfomc/engine/compilation.py
+++ b/src/wfomc/engine/compilation.py
@@ -118,13 +118,16 @@ def compile_reduced_branch(
     for step in problem.decoder_spec.steps:
         if not isinstance(step, CardinalityDecoderSpec):
             continue
-        for predicate, marker in step.predicate_markers:
+        for predicate, marker, exponent in step.predicate_markers:
             positive, negative = weights.get(
                 predicate,
                 (arithmetic.one(), arithmetic.one()),
             )
             weights[predicate] = (
-                arithmetic.multiply(positive, arithmetic.symbol(marker)),
+                arithmetic.multiply(
+                    positive,
+                    arithmetic.power(arithmetic.symbol(marker), exponent),
+                ),
                 negative,
             )
     from wfomc.engine.features import analyze_reduced_features

--- a/src/wfomc/engine/compilation.py
+++ b/src/wfomc/engine/compilation.py
@@ -200,6 +200,7 @@ def _instantiate_decoder(
                         )
                     ),
                     step.predicate_markers,
+                    step.marker_encoding,
                 )
             )
         else:
@@ -230,6 +231,7 @@ def _instantiate_decoder(
                     concrete[1],
                     concrete[2],
                     arithmetic,
+                    marker_encoding=concrete[3],
                 )
         return value
 

--- a/src/wfomc/reduction/cardinality.py
+++ b/src/wfomc/reduction/cardinality.py
@@ -12,6 +12,7 @@ from wfomc.cardinality_constraints import (
 )
 from wfomc.stages import (
     CardinalityDecoderSpec,
+    CardinalityMarkerEncoding,
     DomainExpr,
     ReducedCardinalityConstraint,
     ReducedProblem,
@@ -43,18 +44,9 @@ def encode_cardinality_constraints(problem: ReducedProblem) -> ReducedProblem:
 
     predicate_markers: list[tuple[object, str, int]] = []
     limits = dict(problem.internal_weight_degree_limits)
-    shared_linear_form_encoding = False
-    coefficients: dict[object, int] = {}
-    if len(constraints) == 1:
-        for term in constraints[0].terms:
-            coefficients[term.predicate] = (
-                coefficients.get(term.predicate, 0) + term.coefficient
-            )
-        shared_linear_form_encoding = (
-            any(coefficient > 0 for coefficient in coefficients.values())
-            and all(coefficient >= 0 for coefficient in coefficients.values())
-        )
-    if shared_linear_form_encoding:
+    linear_form_coefficients = _shared_linear_form_coefficients(constraints)
+    if linear_form_coefficients is not None:
+        marker_encoding = CardinalityMarkerEncoding.SHARED_LINEAR_FORM
         # Encoding P's positive weight with z**a makes the degree of z equal
         # the complete linear form sum(a * |P|), so one constraint needs only
         # one generating-function variable.
@@ -63,12 +55,13 @@ def encode_cardinality_constraints(problem: ReducedProblem) -> ReducedProblem:
         predicate_markers.extend(
             (predicate, marker, coefficient)
             for predicate, coefficient in sorted(
-                coefficients.items(), key=lambda item: str(item[0])
+                linear_form_coefficients.items(),
+                key=lambda item: str(item[0]),
             )
             if coefficient > 0
         )
         if (
-            len(predicate_markers) == len(coefficients)
+            len(predicate_markers) == len(linear_form_coefficients)
             and constraint.comparator
             in (Comparator.EQ, Comparator.LE, Comparator.LT)
         ):
@@ -83,6 +76,7 @@ def encode_cardinality_constraints(problem: ReducedProblem) -> ReducedProblem:
                 else DomainExpr.minimum(limits[marker], bound)
             )
     else:
+        marker_encoding = CardinalityMarkerEncoding.PER_PREDICATE
         predicates = sorted(
             {
                 term.predicate
@@ -98,7 +92,7 @@ def encode_cardinality_constraints(problem: ReducedProblem) -> ReducedProblem:
     marker_names = tuple(
         sorted({marker for _predicate, marker, _exponent in predicate_markers})
     )
-    if not shared_linear_form_encoding:
+    if marker_encoding is CardinalityMarkerEncoding.PER_PREDICATE:
         degree_bounds = _safe_predicate_upper_bounds(constraints)
         for predicate, marker, _exponent in predicate_markers_tuple:
             bound = degree_bounds.get(predicate)
@@ -117,7 +111,11 @@ def encode_cardinality_constraints(problem: ReducedProblem) -> ReducedProblem:
         ),
         internal_weight_degree_limits=tuple(sorted(limits.items())),
         decoder_spec=problem.decoder_spec.append(
-            CardinalityDecoderSpec(constraints, predicate_markers_tuple)
+            CardinalityDecoderSpec(
+                constraints,
+                predicate_markers_tuple,
+                marker_encoding,
+            )
         ),
     )
 
@@ -140,6 +138,8 @@ def decode_cardinality_result(
     constraints: CardinalityConstraints,
     predicate_markers: tuple[tuple[object, str, int], ...],
     arithmetic: ArithmeticContext,
+    *,
+    marker_encoding: CardinalityMarkerEncoding,
 ) -> object:
     from flint import fmpq, fmpq_mpoly, fmpq_poly
 
@@ -147,14 +147,19 @@ def decode_cardinality_result(
         return value if _valid_degrees(constraints, {}) else arithmetic.zero()
     if isinstance(value, fmpq_poly):
         markers = {marker for _predicate, marker, _exponent in predicate_markers}
-        if len(markers) != 1 or len(constraints.constraints) != 1:
+        if len(markers) != 1:
             raise TypeError(
-                "univariate cardinality result requires exactly one linear form"
+                "univariate cardinality result requires exactly one marker"
             )
-        constraint = constraints.constraints[0]
+        marker = next(iter(markers))
         accepted = fmpq(0)
         for degree, coefficient in enumerate(value.coeffs()):
-            if constraint.accepts(degree):
+            if _valid_marker_degrees(
+                constraints,
+                predicate_markers,
+                {marker: degree},
+                marker_encoding,
+            ):
                 accepted += coefficient
         # Keep the selected backend until all earlier reduction decoders have
         # applied their factors; the engine projects this constant afterwards.
@@ -168,27 +173,17 @@ def decode_cardinality_result(
         for _predicate, marker, _exponent in predicate_markers
         if marker in names
     }
-    shared_linear_form = (
-        len(marker_indices) == 1
-        and len(constraints.constraints) == 1
-        and len(predicate_markers) > 1
-    )
     valid_terms = {
         monomial: coefficient
         for monomial, coefficient in value.to_dict().items()
-        if (
-            constraints.constraints[0].accepts(
-                monomial[next(iter(marker_indices.values()))]
-            )
-            if shared_linear_form
-            else _valid_degrees(
-                constraints,
-                {
-                    predicate: monomial[marker_indices[marker]] // exponent
-                    for predicate, marker, exponent in predicate_markers
-                    if marker in marker_indices
-                },
-            )
+        if _valid_marker_degrees(
+            constraints,
+            predicate_markers,
+            {
+                marker: monomial[index]
+                for marker, index in marker_indices.items()
+            },
+            marker_encoding,
         )
     }
     filtered = value.context().from_dict(valid_terms)
@@ -202,6 +197,57 @@ def decode_cardinality_result(
     # applied their correction factors.  The engine projects away marker
     # symbols once the complete decoder chain has finished.
     return filtered
+
+
+def _shared_linear_form_coefficients(
+    constraints: tuple[ReducedCardinalityConstraint, ...],
+) -> dict[object, int] | None:
+    """Return a nonnegative single linear form that can share one marker."""
+
+    if len(constraints) != 1:
+        return None
+    coefficients: dict[object, int] = {}
+    for term in constraints[0].terms:
+        coefficients[term.predicate] = (
+            coefficients.get(term.predicate, 0) + term.coefficient
+        )
+    if (
+        not any(coefficient > 0 for coefficient in coefficients.values())
+        or any(coefficient < 0 for coefficient in coefficients.values())
+    ):
+        return None
+    return coefficients
+
+
+def _valid_marker_degrees(
+    constraints: CardinalityConstraints,
+    predicate_markers: tuple[tuple[object, str, int], ...],
+    marker_degrees: Mapping[str, int],
+    marker_encoding: CardinalityMarkerEncoding,
+) -> bool:
+    if marker_encoding is CardinalityMarkerEncoding.SHARED_LINEAR_FORM:
+        markers = {marker for _predicate, marker, _exponent in predicate_markers}
+        if len(markers) != 1 or len(constraints.constraints) != 1:
+            raise TypeError(
+                "shared linear-form encoding requires one marker and one constraint"
+            )
+        return constraints.constraints[0].accepts(
+            marker_degrees.get(next(iter(markers)), 0)
+        )
+    if marker_encoding is not CardinalityMarkerEncoding.PER_PREDICATE:
+        raise TypeError(
+            f"Unsupported cardinality marker encoding: {marker_encoding}"
+        )
+
+    degrees: dict[object, int] = {}
+    for predicate, marker, exponent in predicate_markers:
+        if exponent <= 0:
+            raise ValueError("cardinality marker exponents must be positive")
+        marker_degree = marker_degrees.get(marker, 0)
+        if marker_degree % exponent != 0:
+            return False
+        degrees[predicate] = marker_degree // exponent
+    return _valid_degrees(constraints, degrees)
 
 
 def _valid_degrees(

--- a/src/wfomc/reduction/cardinality.py
+++ b/src/wfomc/reduction/cardinality.py
@@ -58,12 +58,11 @@ def encode_cardinality_constraints(problem: ReducedProblem) -> ReducedProblem:
                 linear_form_coefficients.items(),
                 key=lambda item: str(item[0]),
             )
-            if coefficient > 0
         )
-        if (
-            len(predicate_markers) == len(linear_form_coefficients)
-            and constraint.comparator
-            in (Comparator.EQ, Comparator.LE, Comparator.LT)
+        if constraint.comparator in (
+            Comparator.EQ,
+            Comparator.LE,
+            Comparator.LT,
         ):
             bound = (
                 constraint.rhs - 1
@@ -202,7 +201,7 @@ def decode_cardinality_result(
 def _shared_linear_form_coefficients(
     constraints: tuple[ReducedCardinalityConstraint, ...],
 ) -> dict[object, int] | None:
-    """Return a nonnegative single linear form that can share one marker."""
+    """Return a strictly positive single linear form that can share one marker."""
 
     if len(constraints) != 1:
         return None
@@ -211,9 +210,13 @@ def _shared_linear_form_coefficients(
         coefficients[term.predicate] = (
             coefficients.get(term.predicate, 0) + term.coefficient
         )
-    if (
-        not any(coefficient > 0 for coefficient in coefficients.values())
-        or any(coefficient < 0 for coefficient in coefficients.values())
+    coefficients = {
+        predicate: coefficient
+        for predicate, coefficient in coefficients.items()
+        if coefficient != 0
+    }
+    if not coefficients or any(
+        coefficient < 0 for coefficient in coefficients.values()
     ):
         return None
     return coefficients

--- a/src/wfomc/reduction/cardinality.py
+++ b/src/wfomc/reduction/cardinality.py
@@ -28,33 +28,87 @@ def encode_cardinality_constraints(problem: ReducedProblem) -> ReducedProblem:
     constraints = problem.cardinality_constraints
     if not constraints:
         return problem
-    predicates = sorted(
-        {term.predicate for constraint in constraints for term in constraint.terms},
-        key=str,
-    )
     user_symbols = collect_output_weight_variables(
         problem.weights,
         problem.internal_weight_symbols,
     )
     used_symbols = set(user_symbols) | set(problem.internal_weight_symbols)
-    predicate_markers = []
-    for index, predicate in enumerate(predicates):
+
+    def fresh_marker(index: int) -> str:
         marker = f"__wfomc_cardinality_{index}"
         while marker in used_symbols:
             marker += "_"
         used_symbols.add(marker)
-        predicate_markers.append((predicate, marker))
-    predicate_markers_tuple = tuple(predicate_markers)
-    marker_names = tuple(marker for _predicate, marker in predicate_markers)
-    degree_bounds = _safe_predicate_upper_bounds(constraints)
+        return marker
+
+    predicate_markers: list[tuple[object, str, int]] = []
     limits = dict(problem.internal_weight_degree_limits)
-    for predicate, marker in predicate_markers_tuple:
-        bound = degree_bounds.get(predicate)
-        if bound is None:
-            continue
-        limits[marker] = (
-            bound if marker not in limits else DomainExpr.minimum(limits[marker], bound)
+    shared_linear_form_encoding = False
+    coefficients: dict[object, int] = {}
+    if len(constraints) == 1:
+        for term in constraints[0].terms:
+            coefficients[term.predicate] = (
+                coefficients.get(term.predicate, 0) + term.coefficient
+            )
+        shared_linear_form_encoding = (
+            any(coefficient > 0 for coefficient in coefficients.values())
+            and all(coefficient >= 0 for coefficient in coefficients.values())
         )
+    if shared_linear_form_encoding:
+        # Encoding P's positive weight with z**a makes the degree of z equal
+        # the complete linear form sum(a * |P|), so one constraint needs only
+        # one generating-function variable.
+        constraint = constraints[0]
+        marker = fresh_marker(0)
+        predicate_markers.extend(
+            (predicate, marker, coefficient)
+            for predicate, coefficient in sorted(
+                coefficients.items(), key=lambda item: str(item[0])
+            )
+            if coefficient > 0
+        )
+        if (
+            len(predicate_markers) == len(coefficients)
+            and constraint.comparator
+            in (Comparator.EQ, Comparator.LE, Comparator.LT)
+        ):
+            bound = (
+                constraint.rhs - 1
+                if constraint.comparator is Comparator.LT
+                else constraint.rhs
+            )
+            limits[marker] = (
+                bound
+                if marker not in limits
+                else DomainExpr.minimum(limits[marker], bound)
+            )
+    else:
+        predicates = sorted(
+            {
+                term.predicate
+                for constraint in constraints
+                for term in constraint.terms
+            },
+            key=str,
+        )
+        for index, predicate in enumerate(predicates):
+            predicate_markers.append((predicate, fresh_marker(index), 1))
+
+    predicate_markers_tuple = tuple(predicate_markers)
+    marker_names = tuple(
+        sorted({marker for _predicate, marker, _exponent in predicate_markers})
+    )
+    if not shared_linear_form_encoding:
+        degree_bounds = _safe_predicate_upper_bounds(constraints)
+        for predicate, marker, _exponent in predicate_markers_tuple:
+            bound = degree_bounds.get(predicate)
+            if bound is None:
+                continue
+            limits[marker] = (
+                bound
+                if marker not in limits
+                else DomainExpr.minimum(limits[marker], bound)
+            )
     return replace(
         problem,
         cardinality_constraints=(),
@@ -84,7 +138,7 @@ def to_reduced_cardinality_constraint(
 def decode_cardinality_result(
     value: object,
     constraints: CardinalityConstraints,
-    predicate_markers: tuple[tuple[object, str], ...],
+    predicate_markers: tuple[tuple[object, str, int], ...],
     arithmetic: ArithmeticContext,
 ) -> object:
     from flint import fmpq, fmpq_mpoly, fmpq_poly
@@ -92,14 +146,15 @@ def decode_cardinality_result(
     if isinstance(value, fmpq):
         return value if _valid_degrees(constraints, {}) else arithmetic.zero()
     if isinstance(value, fmpq_poly):
-        if len(predicate_markers) != 1:
+        markers = {marker for _predicate, marker, _exponent in predicate_markers}
+        if len(markers) != 1 or len(constraints.constraints) != 1:
             raise TypeError(
-                "univariate cardinality result requires exactly one marker"
+                "univariate cardinality result requires exactly one linear form"
             )
-        predicate, _marker = predicate_markers[0]
+        constraint = constraints.constraints[0]
         accepted = fmpq(0)
         for degree, coefficient in enumerate(value.coeffs()):
-            if _valid_degrees(constraints, {predicate: degree}):
+            if constraint.accepts(degree):
                 accepted += coefficient
         # Keep the selected backend until all earlier reduction decoders have
         # applied their factors; the engine projects this constant afterwards.
@@ -110,24 +165,38 @@ def decode_cardinality_result(
     names = value.context().names()
     marker_indices = {
         marker: names.index(marker)
-        for _predicate, marker in predicate_markers
+        for _predicate, marker, _exponent in predicate_markers
         if marker in names
     }
+    shared_linear_form = (
+        len(marker_indices) == 1
+        and len(constraints.constraints) == 1
+        and len(predicate_markers) > 1
+    )
     valid_terms = {
         monomial: coefficient
         for monomial, coefficient in value.to_dict().items()
-        if _valid_degrees(
-            constraints,
-            {
-                predicate: monomial[marker_indices[marker]]
-                for predicate, marker in predicate_markers
-                if marker in marker_indices
-            },
+        if (
+            constraints.constraints[0].accepts(
+                monomial[next(iter(marker_indices.values()))]
+            )
+            if shared_linear_form
+            else _valid_degrees(
+                constraints,
+                {
+                    predicate: monomial[marker_indices[marker]] // exponent
+                    for predicate, marker, exponent in predicate_markers
+                    if marker in marker_indices
+                },
+            )
         )
     }
     filtered = value.context().from_dict(valid_terms)
     filtered = filtered.subs(
-        {marker: 1 for _predicate, marker in predicate_markers}
+        {
+            marker: 1
+            for _predicate, marker, _exponent in predicate_markers
+        }
     )
     # Keep the expanded arithmetic ring until earlier reduction decoders have
     # applied their correction factors.  The engine projects away marker

--- a/src/wfomc/stages.py
+++ b/src/wfomc/stages.py
@@ -237,7 +237,7 @@ class DivideDecoderSpec:
 @dataclass(frozen=True)
 class CardinalityDecoderSpec:
     constraints: tuple[ReducedCardinalityConstraint, ...]
-    predicate_markers: tuple[tuple[object, str], ...]
+    predicate_markers: tuple[tuple[object, str, int], ...]
 
 
 DecoderStep = DivideDecoderSpec | CardinalityDecoderSpec

--- a/src/wfomc/stages.py
+++ b/src/wfomc/stages.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from fractions import Fraction
 import math
 from typing import TYPE_CHECKING
@@ -234,10 +235,18 @@ class DivideDecoderSpec:
     coefficient: DomainExpr
 
 
+class CardinalityMarkerEncoding(Enum):
+    """Meaning of cardinality-marker polynomial degrees."""
+
+    PER_PREDICATE = "per-predicate"
+    SHARED_LINEAR_FORM = "shared-linear-form"
+
+
 @dataclass(frozen=True)
 class CardinalityDecoderSpec:
     constraints: tuple[ReducedCardinalityConstraint, ...]
     predicate_markers: tuple[tuple[object, str, int], ...]
+    marker_encoding: CardinalityMarkerEncoding
 
 
 DecoderStep = DivideDecoderSpec | CardinalityDecoderSpec
@@ -340,6 +349,7 @@ def _exact_int(value: Fraction, label: str) -> int:
 
 __all__ = [
     "CardinalityDecoderSpec",
+    "CardinalityMarkerEncoding",
     "CompiledBranchInstance",
     "CompiledReducedBranch",
     "DecoderSpec",

--- a/tests/integration/test_solver_results.py
+++ b/tests/integration/test_solver_results.py
@@ -109,6 +109,61 @@ def test_upper_cardinality_constraint_uses_truncated_polynomial_backend(algo):
     assert solve(problem, algo=algo) == 176
 
 
+def test_multiple_constraints_on_one_predicate_use_one_marker():
+    fol = FOLContext()
+    variable = fol.variable("X")
+    predicate = fol.predicate("P", 1)
+    domain_size = 5
+    problem = _problem(
+        sentence=fol.forall(variable, predicate(variable) | ~predicate(variable)),
+        domain=frozenset(
+            fol.constant(f"d{index}") for index in range(domain_size)
+        ),
+        cardinality_constraints=CardinalityConstraints(
+            (
+                LinearCardinalityConstraint(
+                    (CardinalityTerm(predicate),),
+                    Comparator.GE,
+                    1,
+                ),
+                LinearCardinalityConstraint(
+                    (CardinalityTerm(predicate),),
+                    Comparator.LE,
+                    2,
+                ),
+            )
+        ),
+    )
+
+    assert solve(problem, algo=AlgoName.FASTV2) == (
+        comb(domain_size, 1) + comb(domain_size, 2)
+    )
+
+
+def test_negative_coefficient_uses_predicate_count_marker():
+    fol = FOLContext()
+    variable = fol.variable("X")
+    predicate = fol.predicate("P", 1)
+    domain_size = 3
+    problem = _problem(
+        sentence=fol.forall(variable, predicate(variable) | ~predicate(variable)),
+        domain=frozenset(
+            fol.constant(f"d{index}") for index in range(domain_size)
+        ),
+        cardinality_constraints=CardinalityConstraints(
+            (
+                LinearCardinalityConstraint(
+                    (CardinalityTerm(predicate, -1),),
+                    Comparator.LE,
+                    -1,
+                ),
+            )
+        ),
+    )
+
+    assert solve(problem, algo=AlgoName.FASTV2) == 2**domain_size - 1
+
+
 def test_binary_upper_cardinality_constraint_truncates_pair_weights():
     fol = FOLContext()
     left = fol.variable("X")

--- a/tests/integration/test_solver_results.py
+++ b/tests/integration/test_solver_results.py
@@ -21,6 +21,7 @@ from wfomc import (
     parse_problem,
     solve,
 )
+from wfomc.engine import compile_problem, instantiate_problem
 from wfomc.fol import FOLContext
 
 
@@ -138,7 +139,7 @@ def test_binary_upper_cardinality_constraint_truncates_pair_weights():
     )
 
 
-def test_joint_upper_cardinality_constraint_uses_truncated_mpoly_backend():
+def test_joint_upper_cardinality_constraint_uses_one_linear_form_marker():
     fol = FOLContext()
     variable = fol.variable("X")
     first = fol.predicate("P", 1)
@@ -164,9 +165,52 @@ def test_joint_upper_cardinality_constraint_uses_truncated_mpoly_backend():
         ),
     )
 
+    compiled = compile_problem(problem.problem, algo=AlgoName.FASTV2)
+    artifacts = instantiate_problem(compiled, problem.domain)
+    branch = artifacts.branches[0].problem
+
+    assert branch.internal_weight_symbols == ("__wfomc_cardinality_0",)
     assert solve(problem, algo=AlgoName.FASTV2) == sum(
         comb(2 * domain_size, count) for count in range(3)
     )
+
+
+def test_joint_cardinality_marker_tracks_term_coefficients():
+    fol = FOLContext()
+    variable = fol.variable("X")
+    first = fol.predicate("P", 1)
+    second = fol.predicate("Q", 1)
+    domain_size = 3
+    problem = _problem(
+        sentence=fol.forall(
+            variable,
+            (first(variable) | ~first(variable))
+            & (second(variable) | ~second(variable)),
+        ),
+        domain=frozenset(
+            fol.constant(f"d{index}") for index in range(domain_size)
+        ),
+        cardinality_constraints=CardinalityConstraints(
+            (
+                LinearCardinalityConstraint(
+                    (
+                        CardinalityTerm(first, 2),
+                        CardinalityTerm(second, 3),
+                    ),
+                    Comparator.LE,
+                    4,
+                ),
+            )
+        ),
+    )
+
+    expected = sum(
+        comb(domain_size, first_count) * comb(domain_size, second_count)
+        for first_count in range(domain_size + 1)
+        for second_count in range(domain_size + 1)
+        if 2 * first_count + 3 * second_count <= 4
+    )
+    assert solve(problem, algo=AlgoName.FASTV2) == expected
 
 
 def test_internal_cardinality_cap_does_not_truncate_colliding_user_symbol():

--- a/tests/integration/test_solver_results.py
+++ b/tests/integration/test_solver_results.py
@@ -222,11 +222,65 @@ def test_joint_upper_cardinality_constraint_uses_one_linear_form_marker():
 
     compiled = compile_problem(problem.problem, algo=AlgoName.FASTV2)
     artifacts = instantiate_problem(compiled, problem.domain)
+    assert len(artifacts.branches) == 1
     branch = artifacts.branches[0].problem
 
-    assert branch.internal_weight_symbols == ("__wfomc_cardinality_0",)
+    cardinality_symbols = tuple(
+        symbol
+        for symbol in branch.internal_weight_symbols
+        if symbol.startswith("__wfomc_cardinality_")
+    )
+    assert cardinality_symbols == ("__wfomc_cardinality_0",)
     assert solve(problem, algo=AlgoName.FASTV2) == sum(
         comb(2 * domain_size, count) for count in range(3)
+    )
+
+
+def test_canceling_terms_keep_shared_marker_degree_bound():
+    fol = FOLContext()
+    variable = fol.variable("X")
+    canceled = fol.predicate("P", 1)
+    counted = fol.predicate("Q", 1)
+    domain_size = 3
+    problem = _problem(
+        sentence=fol.forall(
+            variable,
+            (canceled(variable) | ~canceled(variable))
+            & (counted(variable) | ~counted(variable)),
+        ),
+        domain=frozenset(
+            fol.constant(f"d{index}") for index in range(domain_size)
+        ),
+        cardinality_constraints=CardinalityConstraints(
+            (
+                LinearCardinalityConstraint(
+                    (
+                        CardinalityTerm(canceled, 1),
+                        CardinalityTerm(canceled, -1),
+                        CardinalityTerm(counted, 1),
+                    ),
+                    Comparator.LE,
+                    2,
+                ),
+            )
+        ),
+    )
+
+    compiled = compile_problem(problem.problem, algo=AlgoName.FASTV2)
+    artifacts = instantiate_problem(compiled, problem.domain)
+    assert len(artifacts.branches) == 1
+    branch = artifacts.branches[0].problem
+
+    cardinality_limits = {
+        symbol: limit
+        for symbol, limit in branch.internal_weight_degree_limits
+        if symbol.startswith("__wfomc_cardinality_")
+    }
+    assert set(cardinality_limits) == {"__wfomc_cardinality_0"}
+    assert cardinality_limits["__wfomc_cardinality_0"].evaluate(domain_size) == 2
+    assert solve(problem, algo=AlgoName.FASTV2) == (
+        2**domain_size
+        * sum(comb(domain_size, count) for count in range(3))
     )
 
 

--- a/tests/unit/reduction/test_cardinality_result.py
+++ b/tests/unit/reduction/test_cardinality_result.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import pytest
+from flint import fmpq_poly
+
+from wfomc.arithmetic import ArithmeticBackend, ArithmeticContext
+from wfomc.cardinality_constraints import (
+    CardinalityConstraints,
+    CardinalityTerm,
+    Comparator,
+    LinearCardinalityConstraint,
+)
+from wfomc.reduction.cardinality import decode_cardinality_result
+from wfomc.stages import CardinalityMarkerEncoding
+
+
+PREDICATE = "P"
+OTHER_PREDICATE = "Q"
+MARKER = "z"
+ARITHMETIC = ArithmeticContext(ArithmeticBackend.FMPQ_POLY, (MARKER,))
+
+
+def _constraint(
+    *terms: CardinalityTerm,
+    comparator: Comparator,
+    rhs: int,
+) -> LinearCardinalityConstraint:
+    return LinearCardinalityConstraint(terms, comparator, rhs)
+
+
+def test_univariate_predicate_marker_supports_multiple_constraints() -> None:
+    constraints = CardinalityConstraints(
+        (
+            _constraint(
+                CardinalityTerm(PREDICATE),
+                comparator=Comparator.GE,
+                rhs=1,
+            ),
+            _constraint(
+                CardinalityTerm(PREDICATE),
+                comparator=Comparator.LE,
+                rhs=2,
+            ),
+        )
+    )
+
+    actual = decode_cardinality_result(
+        fmpq_poly([1, 3, 3, 1]),
+        constraints,
+        ((PREDICATE, MARKER, 1),),
+        ARITHMETIC,
+        marker_encoding=CardinalityMarkerEncoding.PER_PREDICATE,
+    )
+
+    assert actual == fmpq_poly([6])
+
+
+def test_univariate_predicate_marker_respects_negative_coefficients() -> None:
+    constraints = CardinalityConstraints(
+        (
+            _constraint(
+                CardinalityTerm(PREDICATE, -1),
+                comparator=Comparator.LE,
+                rhs=-1,
+            ),
+        )
+    )
+
+    actual = decode_cardinality_result(
+        fmpq_poly([1, 3, 3, 1]),
+        constraints,
+        ((PREDICATE, MARKER, 1),),
+        ARITHMETIC,
+        marker_encoding=CardinalityMarkerEncoding.PER_PREDICATE,
+    )
+
+    assert actual == fmpq_poly([7])
+
+
+def test_shared_linear_form_marker_checks_its_single_constraint() -> None:
+    constraints = CardinalityConstraints(
+        (
+            _constraint(
+                CardinalityTerm(PREDICATE),
+                CardinalityTerm(OTHER_PREDICATE),
+                comparator=Comparator.LE,
+                rhs=1,
+            ),
+        )
+    )
+
+    actual = decode_cardinality_result(
+        fmpq_poly([1, 2, 1]),
+        constraints,
+        (
+            (PREDICATE, MARKER, 1),
+            (OTHER_PREDICATE, MARKER, 1),
+        ),
+        ARITHMETIC,
+        marker_encoding=CardinalityMarkerEncoding.SHARED_LINEAR_FORM,
+    )
+
+    assert actual == fmpq_poly([3])
+
+
+def test_shared_linear_form_marker_rejects_multiple_constraints() -> None:
+    constraints = CardinalityConstraints(
+        (
+            _constraint(
+                CardinalityTerm(PREDICATE),
+                CardinalityTerm(OTHER_PREDICATE),
+                comparator=Comparator.LE,
+                rhs=1,
+            ),
+            _constraint(
+                CardinalityTerm(PREDICATE),
+                comparator=Comparator.GE,
+                rhs=1,
+            ),
+        )
+    )
+
+    with pytest.raises(TypeError, match="one marker and one constraint"):
+        decode_cardinality_result(
+            fmpq_poly([1, 2, 1]),
+            constraints,
+            (
+                (PREDICATE, MARKER, 1),
+                (OTHER_PREDICATE, MARKER, 1),
+            ),
+            ARITHMETIC,
+            marker_encoding=CardinalityMarkerEncoding.SHARED_LINEAR_FORM,
+        )


### PR DESCRIPTION
## Summary
- encode one nonnegative linear cardinality form with a single generating-function marker
- preserve term coefficients by multiplying each predicate's positive weight by `z^coefficient`
- decode the shared marker degree as the complete linear form while retaining the existing fallback for multiple constraints or negative coefficients

This fixes the cardinality reduction used by merged constraints such as `|E1| + |E2| + |E3| = 3n`; it does not include the BP-DP benchmark or algorithm changes.

## Tests
- `40 passed` in the cardinality/reduction-focused test set
- added end-to-end regressions for a shared marker and unequal term coefficients
- full suite reached `109 passed` with no failures before being stopped in an existing long-running cell-graph computation
